### PR TITLE
Update charts to use configurable broker URL via K_SINK env

### DIFF
--- a/charts/workflows/charts/move2kube/INSTALL.md
+++ b/charts/workflows/charts/move2kube/INSTALL.md
@@ -34,15 +34,13 @@ Note that those ssh keys needs to be added in your git repository as well. For b
 
 From `charts` folder run 
 ```console
-helm install move2kube workflows/move2kube
+helm install move2kube workflows/move2kube --namespace=sonataflow-infra
 ```
 Run the following command to apply it to the `move2kubeURL` parameter:
 ```console
 M2K_ROUTE=$(oc -n sonataflow-infra get routes move2kube-route -o yaml | yq -r .spec.host)
 oc -n sonataflow-infra delete ksvc m2k-save-transformation-func &&
-helm upgrade move2kube move2kube --set workflow.move2kubeURL=https://${M2K_ROUTE} &&
-oc -n sonataflow-infra scale deployment serverless-workflow-m2k --replicas=0 &&
-oc -n sonataflow-infra scale deployment serverless-workflow-m2k --replicas=1
+helm upgrade move2kube move2kube --namespace=sonataflow-infra --set workflow.move2kubeURL=https://${M2K_ROUTE} &&
+oc -n sonataflow-infra scale deployment m2k --replicas=0 &&
+oc -n sonataflow-infra scale deployment m2k --replicas=1
 ```
-
-In all of the above commands, the namespace `sonataflow-infra` is used. Beware that the `namespace` shall be the same as the one specify in [values.yaml](values.yaml) under the `namespace` property.

--- a/charts/workflows/charts/move2kube/templates/01-configmap_01-m2k-resources.yaml
+++ b/charts/workflows/charts/move2kube/templates/01-configmap_01-m2k-resources.yaml
@@ -1872,3 +1872,4 @@ kind: ConfigMap
 metadata:
   creationTimestamp: null
   name: 01-m2k-resources
+  namespace: default

--- a/charts/workflows/charts/move2kube/templates/01-move2kube-instance.yaml
+++ b/charts/workflows/charts/move2kube/templates/01-move2kube-instance.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.instance.name }}
-  namespace: {{ .Values.namespace }}
 spec:
   selector:
     matchLabels:
@@ -50,7 +49,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.instance.name }}-svc
-  namespace: {{ .Values.namespace }}
 spec:
   ports:
     - port: 8080
@@ -62,7 +60,6 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ .Values.instance.name }}-route
-  namespace: {{ .Values.namespace }}
 spec:
   tls:
     termination: edge

--- a/charts/workflows/charts/move2kube/templates/01-sonataflow_m2k.yaml
+++ b/charts/workflows/charts/move2kube/templates/01-sonataflow_m2k.yaml
@@ -255,6 +255,9 @@ spec:
     container:
       resources: {}
       image: quay.io/orchestrator/serverless-workflow-move2kube:f6fbb19dd531f5bcb612b28862a2303dfae87bd7
+      env:
+        - name: K_SINK
+          value: {{ .Values.brokerURL}}
   resources:
     configMaps:
       - configMap:

--- a/charts/workflows/charts/move2kube/templates/02-configmap_m2k-props.yaml
+++ b/charts/workflows/charts/move2kube/templates/02-configmap_m2k-props.yaml
@@ -8,11 +8,12 @@ data:
     mp.messaging.incoming.kogito_incoming_stream.method=POST
 
     # This property is used when sending the notification while waiting for Q&A
-    move2kube_url=${MOVE2KUBE_URL:http://move2kube-svc.default.svc.cluster.local:8080}
+    move2kube_url={{ .Values.workflow.move2kubeURL }}
     # This property is used to send requests to the move2kube instance
-    quarkus.rest-client.move2kube_yaml.url=${MOVE2KUBE_URL:http://move2kube-svc.default.svc.cluster.local:8080}
+    quarkus.rest-client.move2kube_yaml.url={{ .Values.workflow.move2kubeURL }}
     # This property is used to send requests to the backstage notification plugin
-    quarkus.rest-client.notifications.url=${BACKSTAGE_NOTIFICATIONS_URL:http://orchestrator-backstage.orchestrator/api/notifications/}
+    quarkus.rest-client.notifications.url={{ .Values.workflow.backstageNotificationURL }}
+    #quarkus.log.category.\"org.apache.http\".level=DEBUG
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/charts/workflows/charts/move2kube/templates/03-knative-resources.yaml
+++ b/charts/workflows/charts/move2kube/templates/03-knative-resources.yaml
@@ -2,7 +2,6 @@ apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: error-trigger-{{ .Values.workflow.name }}
-  namespace: {{ .Values.namespace }}
 spec:
   broker: {{ .Values.brokerName }}
   filter:
@@ -18,7 +17,6 @@ apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: transformation-saved-trigger-{{ .Values.workflow.name }}
-  namespace: {{ .Values.namespace }}
 spec:
   broker: {{ .Values.brokerName }}
   filter:
@@ -34,13 +32,11 @@ apiVersion: eventing.knative.dev/v1
 kind: Broker
 metadata:
   name: {{ .Values.brokerName }}
-  namespace: {{ .Values.namespace }}
 ---
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: {{ .Values.kfunction.name }}
-  namespace: {{ .Values.namespace }}
 spec:
   template:
     metadata:
@@ -69,8 +65,6 @@ spec:
               value: saveTransformation
             - name: SSH_PRIV_KEY_PATH
               value: /home/jboss/.ssh/id_rsa
-            - name: BROKER_URL
-              value: http://broker-ingress.knative-eventing.svc.cluster.local/sonataflow-infra/default
             - name: MOVE2KUBE_API
               value: {{ .Values.workflow.move2kubeURL }}/api/v1
           name: user-container
@@ -104,7 +98,6 @@ apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: m2k-save-transformation-event
-  namespace: {{ .Values.namespace }}
 spec:
   broker: {{ .Values.brokerName }}
   filter:
@@ -116,21 +109,3 @@ spec:
       kind: Service
       name: {{ .Values.kfunction.name }}
 ---
-apiVersion: sources.knative.dev/v1
-kind: SinkBinding
-metadata:
-  name: {{ .Values.workflow.name }}-sb
-  namespace: {{ .Values.namespace }}
-spec:
-  subject:
-    apiVersion: v1/apps
-    kind: Deployment
-    selector:
-      matchLabels:
-        app: {{ .Values.workflow.name }}
-  sink:
-    ref:
-      apiVersion: eventing.knative.dev/v1
-      kind: Broker
-      name: {{ .Values.brokerName }}
-      namespace: {{ .Values.namespace }}

--- a/charts/workflows/charts/move2kube/values.schema.json
+++ b/charts/workflows/charts/move2kube/values.schema.json
@@ -7,7 +7,6 @@
   "required": [
       "sshSecretName",
       "brokerName",
-      "namespace",
       "workflow",
       "kfunction",
       "instance"
@@ -29,21 +28,12 @@
               "default"
           ]
       },
-      "namespace": {
-          "type": "string",
-          "default": "",
-          "title": "The namespace Schema",
-          "examples": [
-              "sonataflow-infra"
-          ]
-      },
       "workflow": {
           "type": "object",
           "default": {},
           "title": "The workflow Schema",
           "required": [
               "name",
-              "image",
               "move2kubeURL",
               "backstageNotificationURL"
           ],
@@ -54,14 +44,6 @@
                   "title": "The name Schema",
                   "examples": [
                       "serverless-workflow-m2k"
-                  ]
-              },
-              "image": {
-                  "type": "string",
-                  "default": "",
-                  "title": "The image Schema",
-                  "examples": [
-                      "quay.io/orchestrator/serverless-workflow-move2kube:latest"
                   ]
               },
               "move2kubeURL": {
@@ -83,7 +65,6 @@
           },
           "examples": [{
               "name": "serverless-workflow-m2k",
-              "image": "quay.io/orchestrator/serverless-workflow-move2kube:latest",
               "move2kubeURL": "https://move2kube-route-sonataflow-infra.apps.cluster-8xfw.redhatworkshops.io",
               "backstageNotificationURL": "http://orchestrator-backstage.orchestrator/api/notifications/"
           }]

--- a/charts/workflows/charts/move2kube/values.yaml
+++ b/charts/workflows/charts/move2kube/values.yaml
@@ -1,11 +1,10 @@
 sshSecretName: sshkeys # name of the secret holding the ssh keys that will be used by move2kube resources
 brokerName: default # name of the broker used by Knative eventing resources
-namespace: sonataflow-infra # name where install the resources
+brokerURL: http://broker-ingress.knative-eventing.svc.cluster.local/sonataflow-infra/default 
 workflow:
-  name: serverless-workflow-m2k # name of the workflow
-  image: quay.io/orchestrator/serverless-workflow-move2kube:latest # image containing the workflow
+  name: m2k # name of the workflow
   move2kubeURL: https://move2kube-route-sonataflow-infra.apps.cluster-8xfw.redhatworkshops.io # URL for move2kube instace
-  backstageNotificationURL: http://orchestrator-backstage.orchestrator/api/notifications/ # URL for backstage notification plugin
+  backstageNotificationURL: http://orchestrator-backstage.orchestrator:7007/api/notifications/ # URL for backstage notification plugin
 kfunction:
   name: m2k-save-transformation-func # name of the Knative function that save the transformation output to git
   image: quay.io/orchestrator/serverless-workflow-m2k-kfunc:latest # image of the knative function


### PR DESCRIPTION
https://github.com/parodos-dev/serverless-workflows/pull/76 introduces a configurable broker URL using K_SINK env variable.

This PR reflects the needed changes