### PR TITLE
Fix notification props name for m2k

### DIFF
--- a/charts/workflows/charts/move2kube/templates/02-configmap_m2k-props.yaml
+++ b/charts/workflows/charts/move2kube/templates/02-configmap_m2k-props.yaml
@@ -8,16 +8,16 @@ data:
     mp.messaging.incoming.kogito_incoming_stream.method=POST
 
     # This property is used when sending the notification while waiting for Q&A
-    move2kube_url=${MOVE2KUBE_URL:http://move2kube-svc.default.svc.cluster.local:8080}
+    move2kube_url={{ .Values.workflow.move2kubeURL }}
     # This property is used to send requests to the move2kube instance
-    quarkus.rest-client.move2kube_yaml.url=${MOVE2KUBE_URL:http://move2kube-svc.default.svc.cluster.local:8080}
+    quarkus.rest-client.move2kube_yaml.url={{ .Values.workflow.move2kubeURL }}
     # This property is used to send requests to the backstage notification plugin
-    quarkus.rest-client.notifications_yaml.url=${BACKSTAGE_NOTIFICATIONS_URL:http://orchestrator-backstage.orchestrator/api/notifications/}
+    quarkus.rest-client.notifications.url={{ .Values.workflow.backstageNotificationURL }}
+    #quarkus.log.category.\"org.apache.http\".level=DEBUG
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   labels:
-    app: m2k
-    sonataflow.org/workflow-app: m2k
-  name: m2k-props
-  namespace: default
+    app: {{ .Values.workflow.name }}
+    sonataflow.org/workflow-app: {{ .Values.workflow.name }}
+  name: {{ .Values.workflow.name }}-props
+  namespace: {{ .Values.namespace }}


### PR DESCRIPTION
Fix notification props name for m2k

Change is `quarkus.rest-client.notifications_yaml.url=` ==> `quarkus.rest-client.notifications.url=`
Other changes are because of automated PR