### PR TITLE
Specify workflow namespace installation in Helm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The workflows can be installed by the meta chart or individually. Visit workflow
 
 To install workflows by the meta-chart, run:
 ```
-$ helm install orchestrator-workflows orchestrator-workflows/workflows
+$ helm install orchestrator-workflows orchestrator-workflows/workflows --namespace=sonataflow-infra
 ```
 
 ## Configuration

--- a/greeting/README.md
+++ b/greeting/README.md
@@ -9,7 +9,7 @@ There is no configuration required for the greeting workflow to run.
 ## Installation
 
 ```console
-helm install greeting workflows/greeting
+helm install greeting workflows/greeting --namespace=sonataflow-infra
 ```
 
 Verify the greeting workflow is ready:

--- a/move2kube/README.md
+++ b/move2kube/README.md
@@ -36,7 +36,7 @@ Note that those ssh keys needs to be added in your git repository as well. For b
 
 Run 
 ```console
-helm install move2kube workflows/move2kube
+helm install move2kube workflows/move2kube --namespace=sonataflow-infra
 ```
 
 Run the following command to apply it to the `move2kubeURL` parameter:


### PR DESCRIPTION
Specify workflow namespace installation in Helm install

Now that there is no namespace defined in the manifests, we need to specify the sonataflow-infra namespace in the Helm install command