### PR TITLE
Add sleep command before wait for MTA resources

### DIFF
--- a/charts/workflows/charts/mta/INSTALL.md
+++ b/charts/workflows/charts/mta/INSTALL.md
@@ -9,6 +9,7 @@ helm install mta workflows/mta --namespace=sonataflow-infra
 
 Then wait for all resources to be up:
 ```console
+sleep 120s # to wait until the MTA operator has created all requested resources
 oc wait --for=jsonpath='{.status.phase}=Succeeded' -n openshift-mta csv/mta-operator.v6.2.1 --timeout=2m
 oc wait --for=condition=Ready=true pods -l "app.kubernetes.io/name=mta-ui" -n openshift-mta --timeout=2m
 oc wait -n sonataflow-infra sonataflow/mtaanalysis --for=condition=Running --timeout=2m

--- a/charts/workflows/charts/mta/templates/NOTES.txt
+++ b/charts/workflows/charts/mta/templates/NOTES.txt
@@ -13,7 +13,9 @@ MTA operator                                  {{ $mtaOperatorInstalled }}       
 serverless workflow - mta analysis                    {{ $mtaWorkflowInstalled }}         {{ .Release.Namespace }}
 {{/* Empty line */}}
 
+
 Run the following commands to wait until the mta analysis workflow dependencies and build are done and workflow is running on namespace {{ .Release.Namespace }}:
+  sleep 120s # to wait until the MTA operator has created all requested resources
   oc wait --for=jsonpath='{.status.phase}=Succeeded' -n openshift-mta csv/mta-operator.v6.2.1 {{ $timeout }}
   oc wait --for=condition=Ready=true pods -l "app.kubernetes.io/name=mta-ui" -n openshift-mta {{ $timeout }}
   oc wait -n {{ .Release.Namespace }} sonataflow/mtaanalysis --for=condition=Running {{ $timeout }}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/FLPATH-989

The above ticket highlighted the fact that the 2 first wait commands fails because the resources were not created yet by the MTA operator.
By adding a sleep 120s instruction, we ensure that the operator has created the requested resources before waiting for their readiness