### PR TITLE
Add custom steps for MTA and M2K in the global workflows readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ oc delete ksvc m2k-save-transformation-func &&
 helm upgrade  orchestrator-workflows  orchestrator-workflows/workflows --set workflow.move2kubeURL=https://${M2K_ROUTE}
 ```
 
+Then edit the `m2k-props` confimap to set the `quarkus.rest-client.move2kube_yaml.url` and `move2kube_url` properties with the value of `${M2K_ROUTE}`
+
 Run the following to set K_SINK environment variable in the workflow:
 ```console
 BROKER_URL=$(oc get broker -o yaml | yq -r .items[0].status.address.url)

--- a/charts/workflows/charts/move2kube/INSTALL.md
+++ b/charts/workflows/charts/move2kube/INSTALL.md
@@ -46,6 +46,8 @@ oc -n ${TARGET_NS} delete ksvc m2k-save-transformation-func &&
 helm upgrade move2kube move2kube --namespace=${TARGET_NS} --set workflow.move2kubeURL=https://${M2K_ROUTE}
 ```
 
+Then edit the `m2k-props` confimap to set the `quarkus.rest-client.move2kube_yaml.url` and `move2kube_url` properties with the value of `${M2K_ROUTE}`
+
 Run the following to set K_SINK environment variable in the workflow:
 ```console
 BROKER_URL=$(oc -n ${TARGET_NS} get broker -o yaml | yq -r .items[0].status.address.url)

--- a/charts/workflows/charts/move2kube/INSTALL.md
+++ b/charts/workflows/charts/move2kube/INSTALL.md
@@ -2,6 +2,10 @@ Move2kube
 ===========
 
 # Configuration
+Set `TARGET_NS` to the target namespace:
+```console
+TARGET_NS=sonataflow-infra
+```
 
 We need to use `initContainers` and `securityContext` in our Knative services to allow SSH key exchange in move2kube workflow, we have to tell Knative to enable that feature:
 ```bash
@@ -14,12 +18,12 @@ We need to use `initContainers` and `securityContext` in our Knative services to
 
 Also, `move2kube` instance runs as root so we need to allow the `default` service account to use `runAsUser`:
 ```console
-oc -n sonataflow-infra adm policy add-scc-to-user anyuid -z default
+oc -n ${TARGET_NS} adm policy add-scc-to-user anyuid -z default
 ```
 
 Create the secret that holds the ssh keys:
 ```console
-oc create secret generic sshkeys --from-file=id_rsa=${HOME}/.ssh/id_rsa --from-file=id_rsa.pub=${HOME}/.ssh/id_rsa.pub -n sonataflow-infra
+oc -n ${TARGET_NS} create secret generic sshkeys --from-file=id_rsa=${HOME}/.ssh/id_rsa --from-file=id_rsa.pub=${HOME}/.ssh/id_rsa.pub
 ```
 If you change the name of the secret, you will also have to updated the value of `sshSecretName` in [values.yaml](values.yaml)
 
@@ -30,11 +34,6 @@ If you do not have ssh keys, you can generate them with `ssh-keygen` command. Yo
 Note that those ssh keys needs to be added in your git repository as well. For bitbucket it should be on the account level (https://bitbucket.org/account/settings/ssh-keys/)
 
 # Installation
-
-Set `TARGET_NS` to the target namespace:
-```console
-TARGET_NS=sonataflow-infra
-```
 
 From `charts` folder run 
 ```console


### PR DESCRIPTION
Add custom steps for MTA and M2K in the global workflows readme to make sure that someone installing the workflows this way will know what to do in order to have the workflows running correctly.

Plus the `helm upgrade` command does not have the same target