### PR TITLE
Fix upgrade command for global workflow chart for M2K

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Run the following command to apply it to the `move2kubeURL` parameter:
 ```console
 M2K_ROUTE=$(oc get routes move2kube-route -o yaml | yq -r .spec.host)
 oc delete ksvc m2k-save-transformation-func &&
-helm upgrade  orchestrator-workflows  orchestrator-workflows/workflows --set workflow.move2kubeURL=https://${M2K_ROUTE}
+helm upgrade  orchestrator-workflows  orchestrator-workflows/workflows --set move2kube.workflow.move2kubeURL=https://${M2K_ROUTE}
 ```
 
 Then edit the `m2k-props` confimap to set the `quarkus.rest-client.move2kube_yaml.url` and `move2kube_url` properties with the value of `${M2K_ROUTE}`


### PR DESCRIPTION
Fix upgrade command for global workflow chart for M2K: when setting a value, we need to specify the subchart name as first prefix