### PR TITLE
Disable m2k workflow by default

### DIFF
--- a/charts/workflows/Chart.yaml
+++ b/charts/workflows/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.10
+version: 0.2.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/workflows/values.schema.json
+++ b/charts/workflows/values.schema.json
@@ -1,88 +1,88 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "http://example.com/example.json",
-  "type": "object",
-  "default": {},
-  "title": "Root Schema",
-  "required": [
-      "mta",
-      "greeting",
-      "move2kube"
-  ],
-  "properties": {
-      "mta": {
-          "type": "object",
-          "default": {},
-          "title": "The mta Schema",
-          "required": [
-              "enabled"
-          ],
-          "properties": {
-              "enabled": {
-                  "type": "boolean",
-                  "default": false,
-                  "title": "The enabled Schema",
-                  "examples": [
-                      true
-                  ]
-              }
-          },
-          "examples": [{
-              "enabled": true
-          }]
-      },
-      "greeting": {
-          "type": "object",
-          "default": {},
-          "title": "The greeting Schema",
-          "required": [
-              "enabled"
-          ],
-          "properties": {
-              "enabled": {
-                  "type": "boolean",
-                  "default": false,
-                  "title": "The enabled Schema",
-                  "examples": [
-                      true
-                  ]
-              }
-          },
-          "examples": [{
-              "enabled": true
-          }]
-      },
-      "move2kube": {
-          "type": "object",
-          "default": {},
-          "title": "The move2kube Schema",
-          "required": [
-              "enabled"
-          ],
-          "properties": {
-              "enabled": {
-                  "type": "boolean",
-                  "default": false,
-                  "title": "The enabled Schema",
-                  "examples": [
-                      true
-                  ]
-              }
-          },
-          "examples": [{
-              "enabled": true
-          }]
-      }
-  },
-  "examples": [{
-      "mta": {
-          "enabled": true
-      },
-      "greeting": {
-          "enabled": true
-      },
-      "move2kube": {
-          "enabled": true
-      }
-  }]
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://example.com/example.json",
+    "type": "object",
+    "default": {},
+    "title": "Root Schema",
+    "required": [
+        "mta",
+        "greeting",
+        "move2kube"
+    ],
+    "properties": {
+        "mta": {
+            "type": "object",
+            "default": {},
+            "title": "The mta Schema",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        true
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": true
+            }]
+        },
+        "greeting": {
+            "type": "object",
+            "default": {},
+            "title": "The greeting Schema",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        true
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": true
+            }]
+        },
+        "move2kube": {
+            "type": "object",
+            "default": {},
+            "title": "The move2kube Schema",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        false
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": false
+            }]
+        }
+    },
+    "examples": [{
+        "mta": {
+            "enabled": true
+        },
+        "greeting": {
+            "enabled": true
+        },
+        "move2kube": {
+            "enabled": false
+        }
+    }]
 }

--- a/charts/workflows/values.yaml
+++ b/charts/workflows/values.yaml
@@ -3,5 +3,4 @@ mta:
 greeting:
   enabled: true # Indicates that greeting workflow is enabled
 move2kube:
-  enabled: true # Indicates that move2kube workflow is enabled
-
+  enabled: false # Indicates that move2kube workflow is enabled


### PR DESCRIPTION
Since move2kube requires additional steps that ends with a failure when deployed with additional workflows, it is being disabled by default. We can revert the decision whem chart hooks are added to address the failures and the required manual steps.